### PR TITLE
Fixing docs on the history-graph card

### DIFF
--- a/card-history-graph.md
+++ b/card-history-graph.md
@@ -9,14 +9,17 @@ History graph is a basic card, allowing you to display [History Graph](https://w
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
 | type | string | **Required** | `history-graph`
-| entities | list | **Required** | Entity id list to use
+| entities | string | **Required** | List of entities to graph.
 | hours_to_show | integer | 24 | Hours to show
 | refresh_interval | integer | 0 | Refresh interval in seconds
+| title | string | Optional | `My Graphs`
 
 **Example**
 
 ```yaml
 - type: history-graph
+  title: 'My Graph'
   entities:
-    - history_graph.recent_switches
+    - sensor.outside_temperature
+    - media_player.lounge_room
 ```

--- a/card-history-graph.md
+++ b/card-history-graph.md
@@ -9,7 +9,7 @@ History graph is a basic card, allowing you to display [History Graph](https://w
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
 | type | string | **Required** | `history-graph`
-| entities | string | **Required** | List of entities to graph.
+| entities | list | **Required** | List of entities to graph.
 | hours_to_show | integer | 24 | Hours to show
 | refresh_interval | integer | 0 | Refresh interval in seconds
 | title | string | Optional | `My Graphs`


### PR DESCRIPTION
After talking in discord for a while we discovered that this card requires a list of discrete elements to graph, instead of a history_graph entity. I've updated these docs accordingly.